### PR TITLE
[BP] Fixes an error related to thesaurus encoding when uploading from…

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -26,15 +26,17 @@ package org.fao.geonet.api.registries.vocabularies;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -863,7 +865,9 @@ public class KeywordsApi {
             Path rdfFile = Files.createTempFile("thesaurus", ".rdf");
             XMLOutputter xmlOutput = new XMLOutputter();
             xmlOutput.setFormat(Format.getCompactFormat());
-            xmlOutput.output(transform, new FileWriter(rdfFile.toFile()));
+            xmlOutput.output(transform,
+                new OutputStreamWriter(new FileOutputStream(rdfFile.toFile().getCanonicalPath()),
+                    StandardCharsets.UTF_8));
             return rdfFile;
 
         }


### PR DESCRIPTION
… a registry

Some thesaurus downloaded from INSPIRE registry are not stored in UTF-8 when GeoNetwork
runs on Windows causing a `Error on line 1: Invalid byte 1 of 1-byte UTF-8 sequence.` Exception.

This commit stores this file using UTF-8 charset.
Backported from master d960f6ca652ca754f206b41f5ce95a7e2ac8ffbb.