### PR TITLE
Bug fixes on Background Layers

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -181,10 +181,16 @@
             if (config.context) {
               mapReady = gnOwsContextService.loadContextFromUrl(
                 config.context, map);
+            } else {
+              //Failback needed for controllers that rely on map creation
+              mapReady = $q.defer();
+              mapReady.resolve();
+              mapReady = mapReady.promise;
             }
           }
-          var creationPromise = $q.when(mapReady).then(function() {
-
+          
+          //This should be called also when resetting the default map
+          $rootScope.$on('owsContextLoaded', function() {
             // extent
             if (config.extent && ol.extent.getWidth(config.extent) &&
               ol.extent.getHeight(config.extent)) {
@@ -196,17 +202,21 @@
               }
             }
 
-            // layers
+            // load layers from Settings
             if (config.layers && config.layers.length) {
               config.layers.forEach(function(layerInfo) {
                 gnMap.createLayerFromProperties(layerInfo, map)
                   .then(function(layer) {
                     if (layer) {
-                      map.addLayer(layer);
+                      layer.displayInLayerManager = false;
+                      layer.set("group", "Background layers");
+                      layer.set("fromGNSettings", true);
+                      gnViewerSettings.bgLayers.push(layer);
                     }
                   });
               });
             }
+            
             if(type == this.VIEWER_MAP) {
               if (mapParams.wmsurl && mapParams.layername) {
                 gnMap.addWmsFromScratch(map, mapParams.wmsurl,
@@ -214,14 +224,15 @@
 
                 then(function(layer) {
                   layer.set('group', mapParams.layergroup);
+                  layer.displayInLayerManager = true;
                   map.addLayer(layer);
                 });
               }
             }
-          }.bind(this));
+          });
 
           // save the promise on the map
-          map.set('creationPromise', creationPromise);
+          map.set('creationPromise', mapReady);
 
           return map;
         }

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -90,6 +90,8 @@
        * @ngdoc method
        * @name gnOwsContextService#loadContext
        * @methodOf gn_viewer.service:gnOwsContextService
+       * 
+       * Return a promise to be able to bind as if it was a loadContextByURL
        *
        * @description
        * Loads a context, ie. creates layers and centers the map
@@ -100,8 +102,8 @@
        *  after the context layers (used to add layers from the map settings)
        */
       this.loadContext = function(text, map, additionalLayers) {
-        // broadcast context load
-        $rootScope.$broadcast('owsContextLoaded');
+        
+        var deferred = $q.defer();
 
         var context = unmarshaller.unmarshalString(text).value;
         // first remove any existing layer
@@ -324,6 +326,13 @@
             firstLoad = false;
           }
         }
+        
+        // broadcast context load
+        $rootScope.$broadcast('owsContextLoaded');
+       
+        deferred.resolve();
+        
+        return deferred.promise;
       };
 
       /**


### PR DESCRIPTION
Layers from Settings weren't restored on "Default Map" button
Fixing order in which map is loaded (list of background layers not properly setup on startup)

This bugs come from before the Projection Switcher implementation. But as now we rely on GeoNetwork settings to store map configuration, they just popped out now.