### PR TITLE
Allow empty contexts (with no layers).

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -185,7 +185,9 @@
               case 'osm':
                 defer.resolve(new ol.layer.Tile({
                   source: new ol.source.OSM(),
-                  title: layerInfo.title || 'OpenStreetMap'
+                  title: layerInfo.title || 'OpenStreetMap',
+                  label: layerInfo.title || 'OpenStreetMap',
+                  group: layerInfo.group
                 }));
                 break;
 
@@ -207,7 +209,9 @@
                 
                 defer.resolve(new ol.layer.Tile({
                   source: new ol.source.XYZ(prop),
-                  title: layerInfo.title || 'TMS Layer'
+                  title: layerInfo.title || 'TMS Layer',
+                  label: layerInfo.title || 'TMS Layer',
+                  group: layerInfo.group
                 }));
                 break;
 
@@ -218,7 +222,9 @@
                     key: layerInfo.key,
                     imagerySet: 'Aerial'
                   }),
-                  title: layerInfo.title || 'Bing Aerial'
+                  title: layerInfo.title || 'Bing Aerial',
+                  label: layerInfo.title || 'Bing Aerial',
+                  group: layerInfo.group
                 }));
                 break;
 
@@ -231,7 +237,9 @@
                 source.set('type', type);
                 defer.resolve(new ol.layer.Tile({
                   source: source,
-                  title: layerInfo.title || 'Stamen'
+                  title: layerInfo.title || 'Stamen',
+                  label: layerInfo.title || 'Stamen',
+                  group: layerInfo.group
                 }));
                 break;
 
@@ -249,12 +257,13 @@
                       if (layerInfo.title) {
                         layer.set('title', layerInfo.title);
                         layer.set('label', layerInfo.title);
+                        layer.set('group', layerInfo.group);
                       }
                       
                       if(layerInfo.attribution) {
                         layer.getSource().setAttributions(layerInfo.attribution);
                       }
-                      
+
                       defer.resolve(layer);
                     });
                 break;
@@ -272,12 +281,13 @@
                       if (layerInfo.title) {
                         layer.set('title', layerInfo.title);
                         layer.set('label', layerInfo.title);
+                        layer.set('group', layerInfo.group);
                       }
                       
                       if(layerInfo.attribution) {
                         layer.getSource().setAttributions(layerInfo.attribution);
                       }
-                      
+
                       defer.resolve(layer);
                     });
                 break;
@@ -1777,7 +1787,8 @@
               case 'osm':
                 return new ol.layer.Tile({
                   source: new ol.source.OSM(),
-                  title: title ||  'OpenStreetMap'
+                  title: title ||  'OpenStreetMap',
+                  label: title ||  'OpenStreetMap'
                 });
               //ALEJO: tms support
               case 'tms':
@@ -1785,7 +1796,8 @@
                   source: new ol.source.XYZ({
                         url: opt.url
                   }),
-                  title: title ||  'TMS Layer'
+                  title: title ||  'TMS Layer',
+                  label: title ||  'TMS Layer'
                 });
               case 'bing_aerial':
                 return new ol.layer.Tile({
@@ -1794,7 +1806,8 @@
                     key: gnViewerSettings.bingKey,
                     imagerySet: 'Aerial'
                   }),
-                  title: title ||  'Bing Aerial'
+                  title: title ||  'Bing Aerial',
+                  label: title ||  'Bing Aerial'
                 });
               case 'stamen':
                 //We make watercolor the default layer
@@ -1805,7 +1818,8 @@
                 source.set('type', type);
                 return new ol.layer.Tile({
                   source: source,
-                  title: title ||  'Stamen'
+                  title: title ||  'Stamen',
+                  label: title ||  'Stamen'
                 });
 
               case 'wmts':

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -208,10 +208,21 @@
                 gnMap.createLayerFromProperties(layerInfo, map)
                   .then(function(layer) {
                     if (layer) {
-                      layer.displayInLayerManager = false;
-                      layer.set("group", "Background layers");
-                      layer.set("fromGNSettings", true);
-                      gnViewerSettings.bgLayers.push(layer);
+
+                      if(map.getLayers().getLength() == 0) {
+                        //We have an empty map, this is going to be our background
+                        layer.displayInLayerManager = false;
+                        layer.background = true;
+                        layer.set('group', 'Background layers');
+                        layer.setVisible(true);
+                        gnViewerSettings.bgLayers = [layer];
+
+                        map.addLayer(layer);
+                        map.getLayers().setAt(0, layer);
+                      } else {
+                        map.addLayer(layer);
+                      }
+                      
                     }
                   });
               });

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -209,20 +209,33 @@
                   .then(function(layer) {
                     if (layer) {
 
-                      if(map.getLayers().getLength() == 0) {
+                      if(gnViewerSettings.bgLayers.length == 0) {
                         //We have an empty map, this is going to be our background
                         layer.displayInLayerManager = false;
                         layer.background = true;
                         layer.set('group', 'Background layers');
                         layer.setVisible(true);
+                        layer.set("currentBackground", true);
+                        
+                        //Do we have any loading background layer?
+                        if(map.getLayers().getLength() > 0) {
+                          map.getLayers().removeAt(0);
+                        }
+                        
+                        //Add our layer as default background
                         gnViewerSettings.bgLayers = [layer];
-
                         map.addLayer(layer);
                         map.getLayers().setAt(0, layer);
+                      } else if(layer.get('group') == 'Background layers') {
+                        layer.displayInLayerManager = false;
+                        layer.background = true;
+                        gnViewerSettings.bgLayers.push(layer);
                       } else {
                         map.addLayer(layer);
                       }
                       
+                      
+                      layer.set("fromGNSettings", true);
                     }
                   });
               });

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -173,12 +173,13 @@
         var self = this;
         var promises = [];
         var overlays = [];
-        if (angular.isArray(layers)) {
 
-          // ----  Clean bg layers
-          if (map.getLayers().getLength() > 0) {
-            map.getLayers().removeAt(0);
-          }
+        // ----  Clean bg layers
+        if (map.getLayers().getLength() > 0) {
+          map.getLayers().removeAt(0);
+        }
+        
+        if (angular.isArray(layers)) {
           var bgLoadingLayer = new ol.layer.Image({
             loading: true,
             label: 'loading',

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -164,7 +164,11 @@
         }
 
         // load the resources & add additional layers if available
-        var layers = context.resourceList.layer;
+        var layers = [];
+        
+        if(context.resourceList && context.resourceList.layer) {
+          layers = context.resourceList.layer;
+        }
         if (additionalLayers) {
           layers = layers.concat(additionalLayers);
         }

--- a/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
+++ b/web/src/main/webapp/WEB-INF/data/data/resources/map/config-viewer.xml
@@ -1,79 +1,79 @@
-<ows-context:OWSContext xmlns:ows-context="http://www.opengis.net/ows-context"
-                        xmlns:ows="http://www.opengis.net/ows"
-                        version="0.3.1" id="ows-context-ex-1-v3">
-  <ows-context:General>
-    <ows:BoundingBox crs="EPSG:27700">
-<!--       <ows:BoundingBox crs="EPSG:3857"> -->     
-       <ows:LowerCorner>-682855 466783</ows:LowerCorner>
-      <ows:UpperCorner>1222145 1275783</ows:UpperCorner>
-      <!-- <ows:LowerCorner>-8604130.477526832 -320097.07393612247</ows:LowerCorner>
-      <ows:UpperCorner>8948257.201654762 8720263.135408245</ows:UpperCorner> -->
-    </ows:BoundingBox>
-  </ows-context:General>
-  <ows-context:ResourceList>
-  <ows-context:Layer queryable="false" name="ospremium"
-                  hidden="false" opacity="1"
-                  group="Background layers">
-      <ows:Title xmlns:ows="http://www.opengis.net/ows">OS Premium</ows:Title>
-      <ows-context:Server service="urn:ogc:serviceType:WMS">
-          <ows-context:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-           xlink:href="https://t0.ads.astuntechnology.com/spatialdata-gov-scot/ospremium/service?"/>
-      </ows-context:Server>
-      <ows-context:StyleList/>
-  </ows-context:Layer>
-   <!-- <ows-context:Layer name="ospremiumbw" hidden="true" group="Background layers" opacity="1">
-      <ows:Title xmlns:ows="http://www.opengis.net/ows">ADS OS Premium GreyScale</ows:Title>
-      <ows-context:Server service="urn:ogc:serviceType:WMS">
-      <ows-context:OnlineResource xlink:href="https://t0.ads.astuntechnology.com/spatialdata-gov-scot/ospremium/service?" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-      </ows-context:Server>
-    </ows-context:Layer>
-
-    <ows-context:Layer name="{type=osm}"
-                       group="Background layers"
-                       hidden="false"
-                       opacity="1">
-      <ows:Title>OpenStreetMap
-      </ows:Title>
-    </ows-context:Layer>
-    <ows-context:Layer name="{type=bing_aerial}"
-                       group="Background layers"
-                       opacity="1">
-      <ows:Title>Bing Aerial</ows:Title>
-    </ows-context:Layer>
-    <ows-context:Layer name="{type=stamen,name=watercolor}"
-                       group="Background layers"
-                       hidden="true"
-                       opacity="1">
-      <ows:Title>Stamen Watercolor</ows:Title>
-    </ows-context:Layer>
-    <ows-context:Layer name="{type=stamen,name=toner}"
-                       group="Background layers"
-                       hidden="true"
-                       opacity="1">
-      <ows:Title>Stamen Toner</ows:Title>
-    </ows-context:Layer> -->
-    <!--
-    Example for TMS:
-
-    <ows-context:Layer name="type=tms,name=capabaseargenmap"
-                       group="Background layers"
-                       hidden="false"
-                       opacity="1">
-      <ows:Title>IGN</ows:Title>
-      <ows-context:Server service="urn:ogc:serviceType:WMTS">
-        <ows-context:OnlineResource xlink:href="http://wms.ign.gob.ar/geoserver/gwc/service/tms/1.0.0/capabaseargenmap@EPSG:3857@png/{z}/{x}/{-y}.png" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-      </ows-context:Server>
-    </ows-context:Layer>
-
-
-    Example for WMTS:
-
-    <ows-context:Layer queryable="false"
-                       name="{type=wmts,name=web_mercator_etopo1_hillshade}"
-                       hidden="true" opacity="1" group="Background layers">
-      <ows:Title xmlns:ows="http://www.opengis.net/ows">Etopo1</ows:Title>
-      <ows-context:Server service="urn:ogc:serviceType:WMS">
-        <ows-context:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+<ows-context:OWSContext xmlns:ows-context="http://www.opengis.net/ows-context"                                                      
+                        xmlns:ows="http://www.opengis.net/ows"                                                                      
+                        version="0.3.1" id="ows-context-ex-1-v3">                                                                   
+  <ows-context:General>                                                                                                             
+    <ows:BoundingBox crs="EPSG:27700">                                                                                              
+<!--       <ows:BoundingBox crs="EPSG:3857"> -->                                                                                    
+       <ows:LowerCorner>-682855 466783</ows:LowerCorner>                                                                            
+      <ows:UpperCorner>1222145 1275783</ows:UpperCorner>                                                                            
+      <!-- <ows:LowerCorner>-8604130.477526832 -320097.07393612247</ows:LowerCorner>                                                
+      <ows:UpperCorner>8948257.201654762 8720263.135408245</ows:UpperCorner> -->                                                    
+    </ows:BoundingBox>                                                                                                              
+  </ows-context:General>                                                                                                            
+<ows-context:ResourceList>                                                                                                   
+  <!-- <ows-context:Layer queryable="false" name="ospremium"                                                                             
+                  hidden="false" opacity="1"                                                                                        
+                  group="Background layers">                                                                                        
+      <ows:Title xmlns:ows="http://www.opengis.net/ows">OS Premium</ows:Title>                                                      
+      <ows-context:Server service="urn:ogc:serviceType:WMS">                                                                        
+          <ows-context:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"                                                    
+           xlink:href="https://t0.ads.astuntechnology.com/spatialdata-gov-scot/ospremium/service?"/>                                
+      </ows-context:Server>                                                                                                         
+      <ows-context:StyleList/>                                                                                                      
+  </ows-context:Layer> -->                                                                                                          
+   <!-- <ows-context:Layer name="ospremiumbw" hidden="true" group="Background layers" opacity="1">                                  
+      <ows:Title xmlns:ows="http://www.opengis.net/ows">ADS OS Premium GreyScale</ows:Title>                                        
+      <ows-context:Server service="urn:ogc:serviceType:WMS">                                                                        
+      <ows-context:OnlineResource xlink:href="https://t0.ads.astuntechnology.com/spatialdata-gov-scot/ospremium/service?" xmlns:xlink="http://www.w3.org/1999/xlink"/>                                                                                                  
+      </ows-context:Server>                                                                                                         
+    </ows-context:Layer>                                                                                                            
+                                                                                                                                    
+    <ows-context:Layer name="{type=osm}"                                                                                            
+                       group="Background layers"                                                                                    
+                       hidden="false"                                                                                               
+                       opacity="1">                                                                                                 
+      <ows:Title>OpenStreetMap                                                                                                      
+      </ows:Title>                                                                                                                  
+    </ows-context:Layer>                                                                                                            
+    <ows-context:Layer name="{type=bing_aerial}"                                                                                    
+                       group="Background layers"                                                                                    
+                       opacity="1">                                                                                                 
+      <ows:Title>Bing Aerial</ows:Title>                                                                                            
+    </ows-context:Layer>                                                                                                            
+    <ows-context:Layer name="{type=stamen,name=watercolor}"                                                                         
+                       group="Background layers"                                                                                    
+                       hidden="true"                                                                                                
+                       opacity="1">                                                                                                 
+      <ows:Title>Stamen Watercolor</ows:Title>                                                                                      
+    </ows-context:Layer>                                                                                                            
+    <ows-context:Layer name="{type=stamen,name=toner}"                                                                              
+                       group="Background layers"                                                                                    
+                       hidden="true"                                                                                                
+                       opacity="1">                                                                                                 
+      <ows:Title>Stamen Toner</ows:Title>                                                                                           
+    </ows-context:Layer> -->                                                                                                        
+    <!--                                                                                                                            
+    Example for TMS:                                                                                                                
+                                                                                                                                    
+    <ows-context:Layer name="type=tms,name=capabaseargenmap"                                                                        
+                       group="Background layers"                                                                                    
+                       hidden="false"                                                                                               
+                       opacity="1">                                                                                                 
+      <ows:Title>IGN</ows:Title>                                                                                                    
+      <ows-context:Server service="urn:ogc:serviceType:WMTS">                                                                       
+        <ows-context:OnlineResource xlink:href="http://wms.ign.gob.ar/geoserver/gwc/service/tms/1.0.0/capabaseargenmap@EPSG:3857@png/{z}/{x}/{-y}.png" xmlns:xlink="http://www.w3.org/1999/xlink"/>                                                                     
+      </ows-context:Server>                                                                                                         
+    </ows-context:Layer>                                                                                                            
+                                                                                                                                    
+                                                                                                                                    
+    Example for WMTS:                                                                                                               
+                                                                                                                                    
+    <ows-context:Layer queryable="false"                                                                                            
+                       name="{type=wmts,name=web_mercator_etopo1_hillshade}"                                                        
+                       hidden="true" opacity="1" group="Background layers">                                                         
+      <ows:Title xmlns:ows="http://www.opengis.net/ows">Etopo1</ows:Title>                                                          
+      <ows-context:Server service="urn:ogc:serviceType:WMS">                                                                        
+        <ows-context:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"                                                      
                                     xlink:href="http://maps.ngdc.noaa.gov/arcgis/rest/services/web_mercator/etopo1_hillshade/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"/>
       </ows-context:Server>
       <ows-context:StyleList/>


### PR DESCRIPTION
Then the first layer to be loaded from the settings becomes the default background.

This allows us to define different layers per projection.