### PR TITLE
[BP] NullPointerException in metadata notifications management (#3388)

### DIFF
--- a/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
+++ b/core/src/main/java/org/fao/geonet/notifier/MetadataNotifierManager.java
@@ -1,29 +1,28 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
+//===   Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===   United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===   and United Nations Environment Programme (UNEP)
 //===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
+//===   This program is free software; you can redistribute it and/or modify
+//===   it under the terms of the GNU General Public License as published by
+//===   the Free Software Foundation; either version 2 of the License, or (at
+//===   your option) any later version.
 //===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
+//===   This program is distributed in the hope that it will be useful, but
+//===   WITHOUT ANY WARRANTY; without even the implied warranty of
+//===   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===   General Public License for more details.
 //===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===   You should have received a copy of the GNU General Public License
+//===   along with this program; if not, write to the Free Software
+//===   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 //===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
+//===   Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===   Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 package org.fao.geonet.notifier;
 
 import jeeves.server.context.ServiceContext;
-
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Metadata;
@@ -40,13 +39,12 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.springframework.context.ConfigurableApplicationContext;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
 
 
 /**
@@ -78,10 +76,11 @@ public class MetadataNotifierManager {
                     client.webUpdate(notifier, metadata.getData(), metadata.getUuid());
 
                     // mark metadata as notified for current notifier service
-                    setMetadataNotified(metadata.getId(), notifier, false);
+                    setMetadataNotified(metadata.getId(), metadata.getUuid(), notifier, false);
                 }
 
-                Map<Metadata, MetadataNotification> unregisteredMetadataToDelete = getUnnotifiedMetadata(notifier.getId(), MetadataNotificationAction.DELETE);
+                Map<Metadata, MetadataNotification> unregisteredMetadataToDelete =
+                    getUnnotifiedMetadata(notifier.getId(), MetadataNotificationAction.DELETE);
 
                 // process metadata
                 for (Map.Entry<Metadata, MetadataNotification> entry : unregisteredMetadataToDelete.entrySet()) {
@@ -93,7 +92,7 @@ public class MetadataNotifierManager {
                     client.webDelete(notifier, uuid);
 
                     // mark metadata as notified for current notifier service
-                    setMetadataNotified(metadata.getId(), notifier, true);
+                    setMetadataNotified(metadata.getId(), metadata.getUuid(), notifier, true);
                 }
 
             } catch (Exception ex) {
@@ -106,23 +105,26 @@ public class MetadataNotifierManager {
     /**
      * Updates/inserts a metadata record.
      *
-     * @param ISO19139 Metadata content
-     * @param uuid     Metadata uuid identifier
-     * @param context  GeoNetwork context
+     * @param metadataElement Metadata content
+     * @param uuid            Metadata uuid identifier
+     * @param context         GeoNetwork context
+     * @throws MetadataNotifierException
      */
-    public void updateMetadata(Element ISO19139, String id, String uuid, ServiceContext context) throws MetadataNotifierException {
+    public void updateMetadata(Element metadataElement, String id, String uuid, ServiceContext context) {
         final ConfigurableApplicationContext applicationContext = context.getApplicationContext();
         ScheduledThreadPoolExecutor timer = applicationContext.getBean("timerThreadPool", ScheduledThreadPoolExecutor.class);
 
-        timer.schedule(new UpdateTask(ISO19139, id, uuid), 10, TimeUnit.MILLISECONDS);
+        timer.schedule(new UpdateTask(metadataElement, id, uuid), 10, TimeUnit.MILLISECONDS);
     }
 
     /**
      * Deletes a metadata record.
      *
+     * @param uuid
      * @param context GeoNetwork context
+     * @throws MetadataNotifierException
      */
-    public void deleteMetadata(String id, String uuid, ServiceContext context) throws MetadataNotifierException {
+    public void deleteMetadata(String id, String uuid, ServiceContext context) {
         final ConfigurableApplicationContext applicationContext = context.getApplicationContext();
         ScheduledThreadPoolExecutor timer = applicationContext.getBean("timerThreadPool", ScheduledThreadPoolExecutor.class);
         timer.schedule(new DeleteTask(id, uuid), 10, TimeUnit.MILLISECONDS);
@@ -143,9 +145,13 @@ public class MetadataNotifierManager {
 
     /**
      * Retrieves the unnotified metadata to update/insert for a notifier service
+     *
+     * @param notifierId
+     * @return
+     * @throws Exception
      */
     private Map<Metadata, MetadataNotification> getUnnotifiedMetadata(int notifierId,
-                                                                      MetadataNotificationAction... actions) throws Exception {
+                                                                              MetadataNotificationAction... actions) {
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
             Log.debug(Geonet.DATA_MANAGER, "getUnnotifiedMetadata start");
         }
@@ -155,14 +161,14 @@ public class MetadataNotifierManager {
 
         List<MetadataNotification> unNotified = metadataNotificationRepository.findAllNotNotifiedForNotifier(notifierId, actions);
 
-        Map<Integer, MetadataNotification> idToNotification = new HashMap<Integer, MetadataNotification>();
+        Map<Integer, MetadataNotification> idToNotification = new HashMap<>();
         for (MetadataNotification metadataNotification : unNotified) {
             idToNotification.put(metadataNotification.getId().getMetadataId(), metadataNotification);
 
         }
 
         final Iterable<Metadata> allMetadata = metadataRepository.findAll(idToNotification.keySet());
-        Map<Metadata, MetadataNotification> notificationMap = new HashMap<Metadata, MetadataNotification>();
+        Map<Metadata, MetadataNotification> notificationMap = new HashMap<>();
 
         for (Metadata metadata : allMetadata) {
             notificationMap.put(metadata, idToNotification.get(metadata.getId()));
@@ -178,9 +184,10 @@ public class MetadataNotifierManager {
      * Marks a metadata record as notified for a notifier service.
      *
      * @param deleteNotification Indicates if the notification was a delete action
+     * @throws Exception
      */
-    private void setMetadataNotified(int metadataId, MetadataNotifier notifier,
-                                     boolean deleteNotification) throws Exception {
+    private void setMetadataNotified(final int metadataId, final String uuid, final MetadataNotifier notifier,
+                                     final boolean deleteNotification) {
 
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
         MetadataNotificationRepository metadataNotificationRepository = applicationContext.getBean(MetadataNotificationRepository.class);
@@ -188,17 +195,25 @@ public class MetadataNotifierManager {
         final MetadataNotificationId notificationId = new MetadataNotificationId().
             setMetadataId(metadataId).
             setNotifierId(notifier.getId());
+        MetadataNotification notification = metadataNotificationRepository.findOne(notificationId);
+        if (notification == null) {
+            notification = new MetadataNotification();
+            notification.setId(notificationId);
+        }
+        notification.setMetadataUuid(uuid);
+        notification.setNotified(true);
         if (deleteNotification) {
-            metadataNotificationRepository.delete(notificationId);
+            notification.setAction(MetadataNotificationAction.DELETE);
         } else {
-            MetadataNotification notification = metadataNotificationRepository.findOne(notificationId);
+            notification.setMetadataUuid(uuid);
             notification.setNotified(true);
             notification.setAction(MetadataNotificationAction.UPDATE);
-            metadataNotificationRepository.save(notification);
         }
+        metadataNotificationRepository.save(notification);
+
 
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-            Log.debug(Geonet.DATA_MANAGER, "setMetadataNotified finished for metadata with id " + metadataId + "and notifier with id "
+            Log.debug(Geonet.DATA_MANAGER, "setMetadataNotified finished for metadata with id " + metadataId + " and notifier with id "
                 + notifier.getId());
         }
     }
@@ -207,9 +222,10 @@ public class MetadataNotifierManager {
      * Marks a metadata record as notified for a notifier service.
      *
      * @param metadataId Metadata identifier
+     * @throws Exception
      */
-    private void setMetadataNotifiedError(final int metadataId, final MetadataNotifier notifier,
-                                          final boolean deleteNotification, final String error) throws Exception {
+    private void setMetadataNotifiedError(final int metadataId, final String uuid, final MetadataNotifier notifier,
+                                          final boolean deleteNotification, final String error) {
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
             Log.debug(Geonet.DATA_MANAGER, "setMetadataNotifiedError");
         }
@@ -219,18 +235,34 @@ public class MetadataNotifierManager {
                 .class);
 
             MetadataNotificationId id = new MetadataNotificationId().setMetadataId(metadataId).setNotifierId(notifier.getId());
-            metadataNotificationRepository.update(id, new Updater<MetadataNotification>() {
-                @Override
-                public void apply(@Nonnull MetadataNotification entity) {
-                    entity.setErrorMessage(error);
-                    if (deleteNotification == true) {
-                        entity.setAction(MetadataNotificationAction.DELETE);
-                    } else {
-                        entity.setAction(MetadataNotificationAction.UPDATE);
-
-                    }
+            MetadataNotification errorNotification = metadataNotificationRepository.findOne(id);
+            if (errorNotification == null) {
+                // Not existing notification
+                errorNotification = new MetadataNotification();
+                errorNotification.setId(id);
+                errorNotification.setNotified(true);
+                errorNotification.setMetadataUuid(uuid);
+                if (deleteNotification) {
+                    errorNotification.setAction(MetadataNotificationAction.DELETE);
+                } else {
+                    errorNotification.setAction(MetadataNotificationAction.UPDATE);
                 }
-            });
+                metadataNotificationRepository.save(errorNotification);
+            } else {
+                // notification already exists. Update it.
+                metadataNotificationRepository.update(id, new Updater<MetadataNotification>() {
+                    @Override
+                    public void apply(@Nonnull MetadataNotification entity) {
+                        entity.setErrorMessage(error);
+                        if (deleteNotification) {
+                            entity.setAction(MetadataNotificationAction.DELETE);
+                        } else {
+                            entity.setAction(MetadataNotificationAction.UPDATE);
+
+                        }
+                    }
+                });
+            }
 
             if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
                 Log.debug(Geonet.DATA_MANAGER, "setMetadataNotifiedError finished for metadata with id " + metadataId + "and notitifer " +
@@ -253,19 +285,19 @@ public class MetadataNotifierManager {
     }
 
     class UpdateTask implements Runnable {
-        private int metadataId;
-        private Element ISO19139;
-        private String uuid;
+        private final int metadataId;
+        private final Element metadataElement;
+        private final String uuid;
 
-        UpdateTask(Element ISO19139, String metadataId, String uuid) {
-            this.metadataId = Integer.valueOf(metadataId);
+        UpdateTask(Element metadataElement, String metadataId, String uuid) {
+            this.metadataId = Integer.parseInt(metadataId);
             this.uuid = uuid;
-            this.ISO19139 = ISO19139;
+            this.metadataElement = metadataElement;
         }
 
         public void run() {
             try {
-                String metadataString = Xml.getString(ISO19139);
+                String metadataString = Xml.getString(metadataElement);
                 if (Log.isDebugEnabled("MetadataNotifierManager")) {
                     Log.debug("MetadataNotifierManager", "updateMetadata before (uuid): " + uuid);
                 }
@@ -284,7 +316,7 @@ public class MetadataNotifierManager {
                         }
 
                         // mark metadata as notified for current notifier service
-                        setMetadataNotified(metadataId, service, false);
+                        setMetadataNotified(metadataId, uuid, service, false);
 
                     } catch (Exception ex) {
                         Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url "
@@ -293,7 +325,7 @@ public class MetadataNotifierManager {
 
                         // mark metadata as not notified for current notifier service
                         try {
-                            setMetadataNotifiedError(metadataId, service, false, ex.getMessage());
+                            setMetadataNotifiedError(metadataId, uuid, service, false, ex.getMessage());
                         } catch (Exception ex2) {
                             Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url " +
                                 service.getUrl() + " " + ex2.getMessage());
@@ -302,17 +334,19 @@ public class MetadataNotifierManager {
 
                 }
             } catch (Exception e) {
+                Log.error("MetadataNotifierManager", "updateTask ERROR (uuid): " + uuid + ", (id): " + metadataId
+                    + " " + e.getMessage());
                 e.printStackTrace();
             }
         }
     }
 
     class DeleteTask implements Runnable {
-        private int metadataId;
-        private String uuid;
+        private final int metadataId;
+        private final String uuid;
 
         DeleteTask(String metadataId, String uuid) {
-            this.metadataId = Integer.valueOf(metadataId);
+            this.metadataId = Integer.parseInt(metadataId);
             this.uuid = uuid;
         }
 
@@ -324,8 +358,6 @@ public class MetadataNotifierManager {
                 for (MetadataNotifier service : loadNotifiers()) {
                     int notifierId = service.getId();
                     String notifierUrl = service.getUrl();
-                    String username = service.getUsername();
-                    String password = String.valueOf(service.getPassword());
 
                     try {
                         if (Log.isDebugEnabled("MetadataNotifierManager")) {
@@ -339,7 +371,7 @@ public class MetadataNotifierManager {
                         System.out.println("deleteMetadata (id): " + metadataId + " notifier id: " + notifierId);
 
                         // mark metadata as notified for current notifier service
-                        setMetadataNotified(metadataId, service, true);
+                        setMetadataNotified(metadataId, uuid, service, true);
                     } catch (Exception ex) {
                         System.out.println("deleteMetadata ERROR:" + ex.getMessage());
 
@@ -349,7 +381,7 @@ public class MetadataNotifierManager {
 
                         // mark metadata as not notified for current notifier service
                         try {
-                            setMetadataNotifiedError(metadataId, service, true, ex.getMessage());
+                            setMetadataNotifiedError(metadataId, uuid, service, true, ex.getMessage());
                         } catch (Exception ex2) {
                             Log.error("MetadataNotifierManager", "updateMetadata ERROR (uuid): " + uuid + "notifier url " +
                                 notifierUrl + " " + ex2.getMessage());
@@ -359,6 +391,8 @@ public class MetadataNotifierManager {
                 }
 
             } catch (Exception e) {
+                Log.error("MetadataNotifierManager", "deleteTask ERROR (uuid): " + uuid + ", (id): " + metadataId
+                    + " " + e.getMessage());
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
Backport of #3383.
* [BP] Don't delete the notification when deleteNotification is true.
Instead mark the notification action as DELETE.
* [BP] Create new MetadataNotification if not exists
Fixes #1184. Create a new MetadataNotification if it doesn't exist in the
database.